### PR TITLE
Install Laravel Dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-alpine
-MAINTAINER Huiren Woo <giantcrabby@gmail.com>
-LABEL maintainer="Huiren Woo <giantcrabby@gmail.com>" \
+MAINTAINER Giuseppe Trombino <g.trombino@gmail.com>
+LABEL maintainer="Giuseppe Trombino <g.trombino@gmail.com>" \
         php="7.1"
 
 RUN BUILD_DEPENDENCIES="build-base \
@@ -39,14 +39,16 @@ RUN BUILD_DEPENDENCIES="build-base \
     && docker-php-ext-enable xdebug \
     && apk del --purge $BUILD_DEPENDENCIES \
     && php -v \
+    && git --version \
     && cd ~ \
+    && curl -O https://raw.githubusercontent.com/laravel/laravel/master/composer.json \
     && EXPECTED_SIGNATURE=$(curl -q -sS https://composer.github.io/installer.sig) \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');") \
     && if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then >&2 echo 'ERROR: Invalid installer signature' && rm composer-setup.php && exit 1; fi \
-    && php composer-setup.php --quiet \
+    && php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer \
     && RESULT=$? \
     && rm composer-setup.php \
-    && echo "" >> composer.lock \
-    && mkdir vendor \
+    && composer --version \
+    && composer install --no-autoloader --no-scripts --no-suggest \
     && exit $RESULT

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN BUILD_DEPENDENCIES="build-base \
         git \
         $BUILD_DEPENDENCIES \
         $DEV_DEPENDENCIES \
-    && docker-php-ext-install mbstring mcrypt pdo_mysql pdo_pgsql curl json intl gd xml zip bz2 opcache \
+    && docker-php-ext-install mbstring mcrypt pdo_mysql pdo_pgsql curl json intl gd xml zip bz2 opcache bcmath \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
     && apk del --purge $BUILD_DEPENDENCIES \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN BUILD_DEPENDENCIES="build-base \
     && echo '@community http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
     && apk update && apk upgrade -U -a && apk add \
         openssh-client \
+        nodejs \
         git \
         $BUILD_DEPENDENCIES \
         $DEV_DEPENDENCIES \


### PR DESCRIPTION
Roll back to having the Laravel Default dependencies installed on this Docker Image.  This is a hybrid between several different sources:
https://github.com/GIANTCRAB/php-laravel-env/commits/master
https://github.com/WithSocial/docker-build/blob/master/Dockerfile
https://laracasts.com/discuss/channels/testing/laravel-ci-testing-with-gitlab?page=2
and my own inventions and wishes...